### PR TITLE
Containers

### DIFF
--- a/Cloud/AWS/s3.md
+++ b/Cloud/AWS/s3.md
@@ -43,15 +43,34 @@ Amazon S3 access control lists (ACLs) enable you to manage access to buckets and
 
 If an application is using a domain-linked S3 bucket that has been deleted by developers and CNAME records from [Amazone Route 53](https://aws.amazon.com/route53/) are still pending deletion, you can claim this unclaimed S3 bucket name by using an other AWS account.
 
+To verify whether bucket takeover may be possible, run:
+
+```bash
+$ curl -s https://<url-to-bucket> | grep -E -q '<Code>NoSuchBucket</Code>|<li>Code: NoSuchBucket</li>' && echo "Subdomain takeover may be possible" || echo "Subdomain takeover is not possible"
+```
+
 References:
 - [Hands-on AWS S3 Bucket Takeover](https://blog.securelayer7.net/hands-on-aws-s3-bucket-account-takeover-vulnerability/)
 - [Sub-Domain Take Over — AWS S3 Bucket](https://towardsaws.com/subdomain-takeover-aws-s3-bucket-4699815d1b62)
+- [Writeup: s3 bucket takeover presented in https://github.com/reddit/rpan-studio/blob/e1782332c75ecb2f774343258ff509788feab7ce/CI/full-build-macos.sh](https://hackerone.com/reports/1285598)
 
 ## Improper ACL permissions
 
 If ACL permissions are misconfigured you can get unauthenticated access to a bucket. Moreover, such permissions may allow you to both read and modify objects.
 
-{% embed url="https://blog.securelayer7.net/hands-on-aws-s3-bucket-vulnerabilities/" %}
+```bash
+# configure AWS CLI
+$ aws configure
+# listing a bucket
+$ aws s3 ls s3://<bucket-name>/
+# create file.txt in a bucket
+$ aws s3 cp s3://<bucket-name>/file.txt
+# remove file.txt in a bucket
+$ aws s3 rm s3://<bucket-name>/file.txt
+```
+
+References:
+- [Hands-on AWS S3 Bucket Vulnerabilities](https://blog.securelayer7.net/hands-on-aws-s3-bucket-vulnerabilities/)
 
 # References
 

--- a/Container/Escaping/cve-list.md
+++ b/Container/Escaping/cve-list.md
@@ -1,0 +1,33 @@
+# RunC
+
+| CVE | Title | Affected versions | References |
+|: --- |: --- |: --- |: --- |
+| [CVE-2021-30465](https://github.com/opencontainers/runc/security/advisories/GHSA-c3xm-pvg7-gh7r) | mount destinations can be swapped via symlink-exchange to cause mounts outside the rootfs | <=1.0.0-rc94 | [Github advisories: GHSA-c3xm-pvg7-gh7r](https://github.com/opencontainers/runc/security/advisories/GHSA-c3xm-pvg7-gh7r)<br>[runc mount destinations can be swapped via symlink-exchange to cause mounts outside the rootfs (CVE-2021-30465)](http://blog.champtar.fr/runc-symlink-CVE-2021-30465/) |
+| [CVE-2019-19921](https://github.com/opencontainers/runc/security/advisories/GHSA-fh74-hm69-rqjw) | procfs race condition with a shared volume mount | <1.0.0-rc10 | [Github advisories: GHSA-fh74-hm69-rqjw](https://github.com/opencontainers/runc/security/advisories/GHSA-fh74-hm69-rqjw) |
+| [CVE-2019-5736](https://nvd.nist.gov/vuln/detail/CVE-2019-5736) | Overwrite host runc binary due to file-descriptor mishandling | <=1.0-rc6 | [CVE-2019-5736: Escape from Docker and Kubernetes containers to root on host](https://blog.dragonsector.pl/2019/02/cve-2019-5736-escape-from-docker-and.html)<br>[Breaking out of Docker via runC – Explaining CVE-2019-5736](https://unit42.paloaltonetworks.com/breaking-docker-via-runc-explaining-cve-2019-5736/) |
+
+# Containerd
+
+| CVE | Title | Affected versions | References |
+|: --- |: --- |: --- |: --- |
+| [CVE-2021-41103](https://github.com/containerd/containerd/security/advisories/GHSA-c2h3-6mxw-7mvq) | Insufficiently restricted permissions on container root and plugin directories | <1.4.11<br><1.5.7 | [Github advisories: GHSA-c2h3-6mxw-7mvq](https://github.com/containerd/containerd/security/advisories/GHSA-c2h3-6mxw-7mvq) |
+| [CVE-2021-32760](https://github.com/containerd/containerd/security/advisories/GHSA-c72p-9xmj-rx3w) | Archive package allows chmod of file outside of unpack target directory | <=1.4.7<br><=1.5.3 | [Github advisories: GHSA-c72p-9xmj-rx3w](https://github.com/containerd/containerd/security/advisories/GHSA-c72p-9xmj-rx3w) |
+| [CVE-2021-21334](https://github.com/containerd/containerd/security/advisories/GHSA-6g2q-w5j3-fwh4) | containerd CRI plugin: environment variables can leak between containers | <=1.3.9<br><= 1.4.3 | [Github advisories: GHSA-6g2q-w5j3-fwh4](https://github.com/containerd/containerd/security/advisories/GHSA-6g2q-w5j3-fwh4) |
+| [CVE-2020-15257](https://research.nccgroup.com/2020/11/30/technical-advisory-containerd-containerd-shim-api-exposed-to-host-network-containers-cve-2020-15257/) | containerd-shim API Exposed to Host Network Containers | <=1.3.7<br>1.4.0<br>1.4.1 | [Technical Advisory: containerd – containerd-shim API Exposed to Host Network Containers (CVE-2020-15257)](https://research.nccgroup.com/2020/11/30/technical-advisory-containerd-containerd-shim-api-exposed-to-host-network-containers-cve-2020-15257/) |
+| [CVE-2020-15157](https://github.com/containerd/containerd/security/advisories/GHSA-742w-89gc-8m9c) | containerd v1.2.x can be coerced into leaking credentials during image pull | < 1.3.0 | [Github advisories: GHSA-742w-89gc-8m9c](https://github.com/containerd/containerd/security/advisories/GHSA-742w-89gc-8m9c)<br>[CVE-2020-15157 "ContainerDrip" Write-up](https://darkbit.io/blog/cve-2020-15157-containerdrip) |
+
+# Linux kernel
+
+| CVE | Title | Required capabilities | References |
+|: --- |: --- |: --- |: --- |
+| [CVE-2021-22555](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22555) | A heap out-of-bounds write in Linux Netfilter | CAP_NET_ADMIN | [CVE-2021-22555: Turning \x00\x00 into 10000$](https://google.github.io/security-research/pocs/linux/cve-2021-22555/writeup.html) |
+| [CVE-2021-31440](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-31440) | The flaw in handling of eBPF programs leads to escalate privileges | CAP_SYS_MODULE | [CVE-2021-31440: AN INCORRECT BOUNDS CALCULATION IN THE LINUX KERNEL EBPF VERIFIER](https://www.zerodayinitiative.com/blog/2021/5/26/cve-2021-31440-an-incorrect-bounds-calculation-in-the-linux-kernel-ebpf-verifier) |
+| [CVE-2020-8835](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8835) |  The bpf verifier (kernel/bpf/verifier.c) did not properly restrict the register bounds for 32-bit operations, leading to out-of-bounds reads and writes in kernel memory | CAP_SYS_ADMIN | [CVE-2020-8835: LINUX KERNEL PRIVILEGE ESCALATION VIA IMPROPER EBPF PROGRAM VERIFICATION](https://www.zerodayinitiative.com/blog/2020/4/8/cve-2020-8835-linux-kernel-privilege-escalation-via-improper-ebpf-program-verification) |
+| [CVE-2017-7308](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7308) | The packet_set_ring function in net/packet/af_packet.c does not properly validate certain block-size data, which allows local users to gain privileges via crafted system calls. | CAP_NET_RAW | [Exploiting the Linux kernel via packet sockets](https://googleprojectzero.blogspot.com/2017/05/exploiting-linux-kernel-via-packet.html) |
+
+# References
+
+- [Container Security Site: Container CVE List](https://www.container-security.site/general_information/container_cve_list.html)
+- Zeronights 2021: Dmitriy Evdokimov – Container escapes Kubernetes edition
+    - [Video](https://www.youtube.com/watch?v=JoLgVBTc73c)
+    - [Slides](https://zeronights.ru/wp-content/uploads/2021/09/zn2021_container_escapes_kubernetes_edition_v4.pdf)

--- a/Container/Escaping/exposed-docker-socket.md
+++ b/Container/Escaping/exposed-docker-socket.md
@@ -5,6 +5,16 @@ The Docker daemon can listen for [Docker Engine API](https://docs.docker.com/eng
 
 By default, Docker runs through a non-networked UNIX socket, which is created at `/var/run/docker.sock` and requires either root permission or docker group membership.
 
+{% hint style="info" %}
+Additionally, pay attention to the runtime sockets of other high-level runtimes:
+- dockershim: `unix:///var/run/dockershim.sock`
+- containerd: `unix:///run/containerd/containerd.sock`
+- cri-o: `unix:///var/run/crio/crio.sock`
+- frakti: `unix:///var/run/frakti.sock`
+- rktlet: `unix:///var/run/rktlet.sock`
+- ...
+{% endhint %}
+
 A `tcp` socket is used to remotely access the Docker daemon, for which the default setup provides un-encrypted and un-authenticated direct access. It is conventional to use port **2375** for un-encrypted, and port **2376** for encrypted communication with the daemon.
 
 On Systemd-based systems, communication with the Docker daemon can occur over the Systemd socket `fd://`.

--- a/Container/Escaping/host-networking-driver.md
+++ b/Container/Escaping/host-networking-driver.md
@@ -2,6 +2,7 @@ If a container was configured with the Docker [host networking driver (--network
 
 For instance, you can use this to sniff and even spoof traffic between host and metadata instance.
 
-# References
+References:
 
 - [Writeup: How to contact Google SRE: Dropping a shell in cloud SQL](https://offensi.com/2020/08/18/how-to-contact-google-sre-dropping-a-shell-in-cloud-sql/)
+- [Metadata service MITM allows root privilege escalation (EKS / GKE)](https://blog.champtar.fr/Metadata_MITM_root_EKS_GKE/)

--- a/Container/container-analysis-tools.md
+++ b/Container/container-analysis-tools.md
@@ -1,0 +1,4 @@
+- [CDK](https://github.com/cdk-team/CDK) - a container penetration toolkit, offering stable exploitation in different slimmed containers without any OS dependency
+- [deepce](https://github.com/stealthcopter/deepce) - Docker Enumeration, Escalation of Privileges and Container Escapes (DEEPCE)
+- [dive](https://github.com/wagoodman/dive) - a tool for exploring each layer in a docker image
+- [SecretScanner](https://github.com/deepfence/SecretScanner) - find secrets and passwords in container images and file systems

--- a/Resources/Software/docker-analysis.md
+++ b/Resources/Software/docker-analysis.md
@@ -1,3 +1,0 @@
-- [deepce](https://github.com/stealthcopter/deepce) - Docker Enumeration, Escalation of Privileges and Container Escapes (DEEPCE)
-- [dive](https://github.com/wagoodman/dive) - a tool for exploring each layer in a docker image.
-- [SecretScanner](https://github.com/deepfence/SecretScanner) - find secrets and passwords in container images and file systems.

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -30,10 +30,12 @@
     - [Container Basics](Container/Overview/basics.md)
     - [Docker Engine](Container/Overview/docker-engine.md)
 - Escaping
+    - [CVE List](Container/Escaping/cve-list.md)
     - [Exposed Docker Socket](Container/Escaping/exposed-docker-socket.md)
     - [Excessive Capabilities](Container/Escaping/excessive-capabilities.md)
     - [Host Networking Driver](Container/Escaping/host-networking-driver.md)
     - [Sensitive Mounts](Container/Escaping/sensitive-mounts.md)
+- [Container Analysis Tools](Container/container-analysis-tools.md)
 
 ## Framework
 

--- a/Web Application/Server Side Request Forgery/post-exploitation.md
+++ b/Web Application/Server Side Request Forgery/post-exploitation.md
@@ -255,7 +255,16 @@ bash-4.4# curl --unix-socket /var/run/docker.sock http://foo/containers/json
 bash-4.4# curl --unix-socket /var/run/docker.sock http://foo/images/json
 ```
 
-{% embed url="/Container/Escaping" %}
+{% embed url="https://0xn3va.gitbook.io/cheat-sheets/container/escaping/exposed-docker-socket" %}
+
+# Docker registry
+
+Docker registry is commonly available on port `5000`. Docker registry can gain access to either read sensitive information stored in container images and/or modify stored container images.
+
+For enumerating repositiories/images pay attention to the following tools:
+- [reg](https://github.com/genuinetools/reg) - Docker registry v2 command line client and repo listing generator with security checks
+- [regclient](https://github.com/regclient/regclient) - Docker and OCI Registry Client in Go and tooling using those libraries
+- [go-pillage-registries](https://github.com/nccgroup/go-pillage-registries) - Pentester-focused Docker registry tool to enumerate and pull images
 
 # Kubernetes
 
@@ -281,6 +290,16 @@ $ curl http://127.0.0.1:2379/v2/keys/?recursive=true
 The kubelet commonly available on the default port `10250`.
 
 {% embed url="https://www.cyberark.com/resources/threat-research-blog/using-kubelet-client-to-attack-the-kubernetes-cluster" %}
+
+# kubelet read-only
+
+The kubelet read-only commonly available on the default port `10255`. This port is generally only seen on older clusters, but can provide some useful information disclosure if present. It is an HTTP API which will have no encryption and no authentication requirements on it, so it is easy to interact with.
+
+The most useful endpoint is `/pods/`:
+
+```bash
+$ curl http://[IP]:10255/pods/ | jq
+```
 
 # Abusing FTP
 
@@ -466,3 +485,4 @@ Redis commonly available on port `6379`.
 - [Blind SSRF exploitation](https://lab.wallarm.com/blind-ssrf-exploitation/)
 - [A Glossary of Blind SSRF Chains](https://github.com/assetnote/blind-ssrf-chains)
 - [Tool: SSRF Proxy](https://github.com/bcoles/ssrf_proxy)
+- [Container Security Site: Attackers - External Checklist](https://www.container-security.site/attackers/external_attacker_checklist.html)


### PR DESCRIPTION
1. Add links to writeups related to escaping from containers
2. Add CVE list for containers
3. Move list tools to the container section
4. Add docker registry and kubelet read-only to SSRF postexploitation